### PR TITLE
Add queue_element attempts to config and queue framework

### DIFF
--- a/robot_framework/config.py
+++ b/robot_framework/config.py
@@ -12,7 +12,7 @@ FAIL_ROBOT_ON_TOO_MANY_ERRORS = True
 # Error screenshot config
 SMTP_SERVER = "smtp.adm.aarhuskommune.dk"
 SMTP_PORT = 25
-SCREENSHOT_SENDER = "robot@friend.dk"
+SCREENSHOT_SENDER = "robot@aarhus.dk"
 
 # Constant/Credential names
 ERROR_EMAIL = "Error Email"

--- a/robot_framework/config.py
+++ b/robot_framework/config.py
@@ -3,6 +3,9 @@
 # The number of times the robot retries on an error before terminating.
 MAX_RETRY_COUNT = 3
 
+# Number of attempts per queue_element (1 is no retry, 2 is 2 total attempts and so on)
+QUEUE_ATTEMPTS = 1
+
 # Whether the robot should be marked as failed if MAX_RETRY_COUNT is reached.
 FAIL_ROBOT_ON_TOO_MANY_ERRORS = True
 


### PR DESCRIPTION
Using the below logic, i've implemented an option to retry per queue element, instead of having a global retry only, so you can both define max_retries and queue_element attempts, so you can customize your process even more depending on what the queue type requires.

```python
attempts = 1  # Number times to try queue_element (1 is no retry, 2 is 2 total attempts and so on)

for attempt in range(1, attempts + 1):
    try:
        print(f"Run {attempt}...")
        break
    except Exception as e:
        print(f"Attempt {attempt} failed: {e}")
        if attempt < attempts:
            print("Retrying...")
        else:
            print(f"Operation failed after {attempt} attempts.")
```

And i've added the following lines to config (and changed default email domain to aarhus.dk to avoid the outlook warning)
```python
# Number of attempts per queue_element (1 is no retry, 2 is 2 total attempts and so on)
QUEUE_ATTEMPTS = 1
```