### PR TITLE
Truncate error_msg for queue elements to avoid crash - Update exceptions.py

### DIFF
--- a/robot_framework/exceptions.py
+++ b/robot_framework/exceptions.py
@@ -30,6 +30,8 @@ def handle_error(message: str, error: Exception, queue_element: QueueElement | N
 
     orchestrator_connection.log_error(error_msg)
     if queue_element:
+        if len(error_msg) > 999:
+            error_msg = error_msg[:490] + "\n... [truncated] ...\n" + error_msg[-490:]
         orchestrator_connection.set_queue_element_status(queue_element.id, QueueStatus.FAILED, error_msg)
     error_screenshot.send_error_screenshot(error_email, error, orchestrator_connection.process_name)
 

--- a/robot_framework/exceptions.py
+++ b/robot_framework/exceptions.py
@@ -31,7 +31,7 @@ def handle_error(message: str, error: Exception, queue_element: QueueElement | N
     orchestrator_connection.log_error(error_msg)
     if queue_element:
         if len(error_msg) > 999:
-            error_msg = error_msg[:490] + "\n... [truncated] ...\n" + error_msg[-490:]
+            error_msg = error_msg[:485] + "\n... [truncated] ...\n" + error_msg[-485:]
         orchestrator_connection.set_queue_element_status(queue_element.id, QueueStatus.FAILED, error_msg)
     error_screenshot.send_error_screenshot(error_email, error, orchestrator_connection.process_name)
 


### PR DESCRIPTION
Truncate error_msg string if larger than 999 for queue_elements 

causes SQL alchemy error  and crashes error handling/trigger due to the sql alchemy model used message: Mapped[Optional[str]] = mapped_column(String(1000))

Type: <class 'sqlalchemy.exc.DBAPIError'>